### PR TITLE
Fail safely on empty lists

### DIFF
--- a/rcdk/R/io.R
+++ b/rcdk/R/io.R
@@ -56,6 +56,8 @@ load.molecules <- function(molfiles=NA, aromaticity = TRUE, typing = TRUE, isoto
 
   if (is.jnull(molecules)) {
     return(NA)
+  } if (length(molecules == 0)) {
+    return(molecules)
   } else {
     nulls <- which( unlist(lapply(molecules, is.jnull)) )
     if (length(nulls) > 0) molecules[nulls] <- NA


### PR DESCRIPTION
Rajarshi,

loading the Fragments2.sdf from the Bioclipse sample data causes and empty list to be returned by your rcdk Java wrapper, causing an error in your R code:

Error in which(unlist(lapply(molecules, is.jnull))) : 
  argument to 'which' is not logical

While the reading of that SD file is still broken, at least it fails safely now, and just returns an empty list.
