### PR TITLE
Update visual.R

### DIFF
--- a/rcdk/R/visual.R
+++ b/rcdk/R/visual.R
@@ -76,7 +76,7 @@ view.molecule.2d <- function(molecule, ncol = 4, cellx = 200, celly = 200) {
 
     if (is.osx) {
       smi <- get.smiles(molecule)
-      cmd <- sprintf('java -cp %s/cont/cdk.jar:%s/cont/rcdk.jar org.guha.rcdk.app.OSXHelper viewMolecule2D "%s" %d %d &', rcdklibs, jarfile, smi, cellx, celly)
+      cmd <- sprintf('java -cp \"%s/cont/*:%s/cont/rcdk.jar\" org.guha.rcdk.app.OSXHelper viewMolecule2D "%s" %d %d &', rcdklibs, jarfile, smi, cellx, celly)
       return(system(cmd))
     } else {
       v2d <- .jnew("org/guha/rcdk/view/ViewMolecule2D", molecule, as.integer(cellx), as.integer(celly))


### PR DESCRIPTION
The cdk.jar file appears to be split out into many smaller jar files now.  Java 6 onwards support wildcards in the classpath option.  This seemed cleaner than listing and adding the full set of jars.