### PR TITLE
Fix documentation and make test compatible with CDK v2.2

### DIFF
--- a/rcdk/inst/unitTests/runit.frags.R
+++ b/rcdk/inst/unitTests/runit.frags.R
@@ -32,5 +32,5 @@ test.frag3 <- function() {
   checkEquals(length(f), 3)
 
   fworks <- unlist(lapply(f, function(x) unlist(lapply(x$frameworks, .jclass))))
-  checkTrue(all(fworks == "org.openscience.cdk.AtomContainer"))
+  checkTrue(all(fworks == "org.openscience.cdk.AtomContainer2"))
 }

--- a/rcdk/inst/unitTests/runit.match.R
+++ b/rcdk/inst/unitTests/runit.match.R
@@ -46,7 +46,7 @@ test.mcs1 <- function() {
   lapply(mols, do.aromaticity)
   lapply(mols, do.typing) 
   mcs <- get.mcs(mols[[1]], mols[[2]], TRUE)
-  checkEquals("org.openscience.cdk.AtomContainer", .jclass(mcs))
+  checkEquals("org.openscience.cdk.AtomContainer2", .jclass(mcs))
   checkEquals(9, get.atom.count(mcs))
 }
 
@@ -55,7 +55,7 @@ test.mcs3 <- function() {
   lapply(mols, do.aromaticity)
   lapply(mols, do.typing) 
   mcs <- get.mcs(mols[[1]], mols[[2]], TRUE)
-  checkEquals("org.openscience.cdk.AtomContainer", .jclass(mcs))
+  checkEquals("org.openscience.cdk.AtomContainer2", .jclass(mcs))
   checkEquals(21, get.atom.count(mcs))
 }
 

--- a/rcdk/man/generateformula.Rd
+++ b/rcdk/man/generateformula.Rd
@@ -23,11 +23,11 @@ generate.formula(mass, window=0.01, elements=list(c("C",0,50),c("H",0,50),
                  validation=FALSE, charge=0.0)
 generate.formula.iter(mass, window = 0.01,
                               elements = list(
-                                C=c(0,50),
-                                H=c(0,50),
-                                N=c(0,50),
-                                O=c(0,50),
-                                S=c(0,50)),
+                                c("C",0,50),
+                                c("H",0,50),
+                                c("N",0,50),
+                                c("O",0,50),
+                                c("S",0,50)),
                               validation = FALSE,
                               charge = 0.0,
                               as.string=TRUE)


### PR DESCRIPTION
Hei, 

when I ran ```R CMD check rcdk_3.4.9.tar.gz``` some tests failed:
```
....
Running the tests in ‘tests/doRUnit.R’ failed.
Last 13 lines of output:
  rcdk rcdk Unit Tests - 28 test functions, 0 errors, 3 failures
  FAILURE in test.frag3: Error in checkTrue(all(fworks == "org.openscience.cdk.AtomContainer")) : 
    Test not TRUE
  
  FAILURE in test.mcs1: Error in checkEquals("org.openscience.cdk.AtomContainer", .jclass(mcs)) : 
    1 string mismatch
  
  FAILURE in test.mcs3: Error in checkEquals("org.openscience.cdk.AtomContainer", .jclass(mcs)) : 
    1 string mismatch
...
```
I fixed those: Since CDK version 2.2 the default atom-container is AtomContainer2 ([link](https://github.com/cdk/cdk/wiki/AtomContainer2#activation)).

There was also some documentation mismatch (compare with #71) that is fixed.

A third issue I could not fix (example in [```rcdk/man/atomcontainer.Rd```](https://github.com/rajarshi/cdkr/blob/master/rcdk/man/atomcontainer.Rd)): 

```R
  m <- parse.smiles('c1ccccc1')[[1]]

  ## Need to configure the molecule
  do.aromaticity(m)
  do.typing(m)
  do.isotopes(m)

  get.exact.mass(m)
``` 
throws an exception:
```
 Java-Object{java.lang.NullPointerException}"
Error in get.exact.mass(m) :
  Couldn't get exact mass. Maybe you have not performed aromaticity, atom type or isotope configuration?
```
The error remains also, when I perform the typing before the aromaticity detection (which probably is the correct order, but got mixed up in the examples). Maybe, we can figure this still out?

Best regards,

Eric

PS: I would like to make the tests pass, as I have some code I wanna contribute to the ```cdkr``` package. I have tests as well and in that way I found out about the mentioned issues.