### PR TITLE
Adding the build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://api.travis-ci.org/rajarshi/cdkr.svg?branch=master)](https://travis-ci.org/rajarshi/cdkr)
+
 ## rcdk
 
 


### PR DESCRIPTION
This adds the link with the Travis build results to the README.md and hence the cdkr page users see first.