### PR TITLE
calculate mass by passing through the molecular formula. The advantag…

### DIFF
--- a/rcdk/R/rcdk.R
+++ b/rcdk/R/rcdk.R
@@ -80,18 +80,31 @@ get.total.hydrogen.count <- function(mol) {
 get.exact.mass <- function(mol) {
   if (!.check.class(mol, "org/openscience/cdk/interfaces/IAtomContainer"))
     stop("molecule must be of class IAtomContainer")
-  ret <- .jcall('org/openscience/cdk/tools/manipulator/AtomContainerManipulator',
+  
+  
+  formulaJ <- .jcall('org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator',
+                     "Lorg/openscience/cdk/interfaces/IMolecularFormula;",
+                     "getMolecularFormula",
+                     molecule,
+                     use.true.class=FALSE);
+  
+  
+  ret <- .jcall('org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator',
                 'D',
                 'getTotalExactMass',
-                mol,
+                formulaJ,
                 check=FALSE)
+  
   ex <- .jgetEx(clear=TRUE)
+  
+  
   if (is.null(ex)) return(ret)
   else{
     print(ex)
     stop("Couldn't get exact mass. Maybe you have not performed aromaticity, atom type or isotope configuration?")
   }
 }
+  
 
 get.natural.mass <- function(mol) {
   if (!.check.class(mol, "org/openscience/cdk/interfaces/IAtomContainer"))

--- a/rcdk/R/rcdk.R
+++ b/rcdk/R/rcdk.R
@@ -85,7 +85,7 @@ get.exact.mass <- function(mol) {
   formulaJ <- .jcall('org/openscience/cdk/tools/manipulator/MolecularFormulaManipulator',
                      "Lorg/openscience/cdk/interfaces/IMolecularFormula;",
                      "getMolecularFormula",
-                     molecule,
+                     mol,
                      use.true.class=FALSE);
   
   


### PR DESCRIPTION
…e here is that the formula manipulator handles isotope assignment of the atoms in the molecule. Isotope assignment (or lack therof)  was causing mass calculations to fail

So it appears the issue is not related to a CDK bug as I first thought (see . https://github.com/cdk/cdk/pull/505). Instead, it seems the  Isotope information is incorrectly set.  Based on the JavaDoc, see [here](https://github.com/cdk/cdk/blob/master/base/core/src/main/java/org/openscience/cdk/config/IsotopeFactory.java#L190), we can use the IAtomContainer->IMolecularFormula-> MolecularFormulaManipulator.getTotalExactMass where the isotope information is handled by the  MolecularFormulaManipulator class.


